### PR TITLE
Add sample inventory and expanded home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project contains a simple front end for the Sterling UTV shop. The site is built with React and Vite and showcases the products and services offered. You can search products and add them to a shopping cart.
 
+The Products page now displays example inventory complete with prices and descriptions.
+
 The main pages are:
 
 - **Home** – landing page for the shop

--- a/frontend/src/data/products.js
+++ b/frontend/src/data/products.js
@@ -1,0 +1,38 @@
+export default [
+  {
+    id: 1,
+    name: 'Lift Kit',
+    price: 799,
+    description: 'Increase your ground clearance with our heavy duty lift kit.',
+  },
+  {
+    id: 2,
+    name: 'LED Light Bar',
+    price: 249,
+    description: 'Light up the trail with a high output 40-inch LED light bar.',
+  },
+  {
+    id: 3,
+    name: 'Roof Rack',
+    price: 399,
+    description: 'Carry more gear with a powder coated steel roof rack.',
+  },
+  {
+    id: 4,
+    name: 'Winch',
+    price: 549,
+    description: 'A 4500lb winch kit to get you out of sticky situations.',
+  },
+  {
+    id: 5,
+    name: 'Half Windshield',
+    price: 199,
+    description: 'Protect yourself from debris while maintaining airflow.',
+  },
+  {
+    id: 6,
+    name: 'Bluetooth Speaker System',
+    price: 299,
+    description: 'Enjoy your favorite tunes with a waterproof speaker setup.',
+  },
+];

--- a/frontend/src/pages/Cart.jsx
+++ b/frontend/src/pages/Cart.jsx
@@ -1,18 +1,22 @@
 export default function Cart({ cart, onRemove }) {
+  const total = cart.reduce((sum, item) => sum + item.price, 0);
   return (
     <section>
       <h2>Your Cart</h2>
       {cart.length === 0 ? (
         <p>Your cart is empty.</p>
       ) : (
-        <ul>
-          {cart.map((item, index) => (
-            <li key={index}>
-              {item}{' '}
-              <button onClick={() => onRemove(index)}>Remove</button>
-            </li>
-          ))}
-        </ul>
+        <>
+          <ul>
+            {cart.map((item, index) => (
+              <li key={index}>
+                <strong>{item.name}</strong> - ${item.price}{' '}
+                <button onClick={() => onRemove(index)}>Remove</button>
+              </li>
+            ))}
+          </ul>
+          <p>Total: ${total}</p>
+        </>
       )}
     </section>
   );

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -2,7 +2,22 @@ export default function Home() {
   return (
     <section>
       <h2>Welcome to Sterling UTV</h2>
-      <p>We specialize in upgrades, repairs, and the best parts for your side-by-side.</p>
+      <p>
+        At Sterling UTV we live and breathe off-road adventure. Whether you need
+        routine maintenance or the latest accessories, our team is ready to help
+        you build the side-by-side of your dreams.
+      </p>
+      <p>Visit our showroom to explore a full line of quality parts including:</p>
+      <ul>
+        <li>Lift kits and suspension upgrades</li>
+        <li>Lighting solutions for night rides</li>
+        <li>Audio systems and storage racks</li>
+      </ul>
+      <p>
+        Browse the Products page to see what's currently in stock or reach out
+        through our Contact page to schedule service with one of our certified
+        mechanics.
+      </p>
     </section>
   );
 }

--- a/frontend/src/pages/Products.jsx
+++ b/frontend/src/pages/Products.jsx
@@ -1,7 +1,8 @@
+import products from '../data/products.js';
+
 export default function Products({ search, onSearch, onAdd }) {
-  const items = ['Lift Kit', 'LED Lights', 'Roof Rack', 'Winch'];
-  const filtered = items.filter((item) =>
-    item.toLowerCase().includes(search.toLowerCase()),
+  const filtered = products.filter((p) =>
+    p.name.toLowerCase().includes(search.toLowerCase()),
   );
 
   return (
@@ -15,8 +16,9 @@ export default function Products({ search, onSearch, onAdd }) {
       />
       <ul>
         {filtered.map((item) => (
-          <li key={item}>
-            {item}{' '}
+          <li key={item.id}>
+            <strong>{item.name}</strong> - ${item.price}
+            <p>{item.description}</p>
             <button onClick={() => onAdd(item)}>Add to Cart</button>
           </li>
         ))}


### PR DESCRIPTION
## Summary
- add example product data
- display product details with price and description
- show cart totals and item details
- expand copy on the home page
- document example inventory in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687db6e899008330a2aa264da3a7e3c6