### PR TITLE
Add responsive navigation

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -14,8 +14,12 @@ nav.nav {
 
 @media (max-width: 599px) {
   nav.nav {
+    display: none;
     flex-direction: column;
     margin-bottom: 1rem;
+  }
+  header.open nav.nav {
+    display: flex;
   }
 }
 

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -10,7 +10,7 @@ export default function Header({ current, onNavigate }) {
   };
 
   return (
-    <header className="header">
+    <header className={`header${open ? ' open' : ''}`}>
       <div className="header-top">
         <h1 className="site-title">Sterling UTV</h1>
         <button
@@ -21,7 +21,7 @@ export default function Header({ current, onNavigate }) {
           &#9776;
         </button>
       </div>
-      {open && <Navbar current={current} onNavigate={handleNavigate} />}
+      <Navbar current={current} onNavigate={handleNavigate} />
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- keep navigation visible on wider screens
- hide navigation behind hamburger menu on small screens

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687dbf535c3883309fe1fce4a004133f