### PR TITLE
Update styling and add page animations

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,9 +1,9 @@
 #root {
-  max-width: 960px;
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
   padding: 2rem;
   background-color: var(--surface-alt);
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
 nav.nav {
@@ -26,7 +26,7 @@ nav.nav {
 
 nav.nav button {
   background-color: var(--surface);
-  color: #f8f9fa;
+  color: #222;
   border: 1px solid #6c757d;
   padding: 0.5rem 1rem;
   transition: background-color 0.2s, transform 0.2s;
@@ -88,8 +88,8 @@ input[type='text'] {
   max-width: 300px;
   border: 1px solid #6c757d;
   border-radius: 4px;
-  background-color: #495057;
-  color: #f8f9fa;
+  background-color: var(--surface);
+  color: #222;
   transition: box-shadow 0.2s;
 }
 input[type='text']:focus {
@@ -101,18 +101,16 @@ input[type='text']:focus {
   text-align: center;
   margin-bottom: 1.5rem;
   font-size: 2.5rem;
-  background: linear-gradient(90deg, var(--primary), #ffd280);
-  -webkit-background-clip: text;
-  color: transparent;
+  color: var(--primary);
 }
 
 header {
   margin-bottom: 1rem;
   position: sticky;
   top: 0;
-  background: linear-gradient(90deg, var(--surface-alt), var(--surface));
+  background-color: var(--surface-alt);
   padding: 0.5rem 1rem;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   backdrop-filter: blur(6px);
   z-index: 10;
 }
@@ -127,7 +125,7 @@ button.hamburger {
   background: none;
   border: none;
   font-size: 1.5rem;
-  color: #f8f9fa;
+  color: #222;
   transition: color 0.2s;
 }
 button.hamburger:hover {
@@ -146,6 +144,50 @@ button.hamburger:hover {
   padding-top: 1rem;
   border-top: 1px solid #495057;
   font-size: 0.9rem;
-  color: #adb5bd;
-  background: linear-gradient(90deg, var(--surface), var(--surface-alt));
+  color: #555;
+  background-color: var(--surface-alt);
+}
+
+.service-list {
+  list-style: none;
+  padding: 0;
+}
+
+.service-item {
+  opacity: 0;
+  transform: translateX(-20px);
+  animation: fadeSlide 0.6s forwards;
+}
+
+.category-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  animation: fadeSlide 0.6s forwards;
+}
+
+.category-icon {
+  display: inline-block;
+  animation: bounce 1s infinite;
+}
+
+@keyframes fadeSlide {
+  from {
+    opacity: 0;
+    transform: translateX(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes bounce {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-5px);
+  }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,11 +1,11 @@
 :root {
-  --primary: #ff8800;
-  --primary-dark: #ff7700;
-  --surface: #212529;
-  --surface-alt: #343a40;
+  --primary: #6dbf6d;
+  --primary-dark: #5aa75c;
+  --surface: #ffffff;
+  --surface-alt: #f0fff4;
   font-family: 'Montserrat', system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.6;
-  color: #f8f9fa;
+  color: #222;
   background-color: var(--surface);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -26,7 +26,7 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
-  background: linear-gradient(135deg, var(--surface) 0%, var(--surface-alt) 100%);
+  background-color: var(--surface);
 }
 
 h1 {

--- a/frontend/src/pages/Products.jsx
+++ b/frontend/src/pages/Products.jsx
@@ -25,12 +25,15 @@ export default function Products({ search, onSearch, onAdd }) {
         value={search}
         onChange={(e) => onSearch(e.target.value)}
       />
-      {categories.map((cat) => {
+      {categories.map((cat, idx) => {
         const items = grouped[cat] || [];
         if (items.length === 0) return null;
         return (
           <div key={cat}>
-            <h3>{cat}</h3>
+            <h3 className="category-heading" style={{ animationDelay: `${idx * 0.1}s` }}>
+              <span className="category-icon">&#9656;</span>
+              {cat}
+            </h3>
             <ul>
               {items.map((item) => (
                 <li key={item.id}>

--- a/frontend/src/pages/Services.jsx
+++ b/frontend/src/pages/Services.jsx
@@ -1,8 +1,25 @@
 export default function Services() {
+  const services = [
+    'Routine Maintenance',
+    'Lift Kit Installation',
+    'Diagnostics',
+    'Custom Fabrication',
+  ];
+
   return (
     <section>
       <h2>Services</h2>
-      <p>From routine maintenance to custom builds, our mechanics keep you on the trail.</p>
+      <ul className="service-list">
+        {services.map((srv, idx) => (
+          <li
+            key={idx}
+            className="service-item"
+            style={{ animationDelay: `${idx * 0.1}s` }}
+          >
+            {srv}
+          </li>
+        ))}
+      </ul>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- make app responsive full width and switch to green/white palette
- drop gradients and tune colors
- animate service list and product categories

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687dd1eba8348330b2937c4f74878712