### PR TITLE
Update services and add product images

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -163,12 +163,19 @@ button.hamburger:hover {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  animation: fadeSlide 0.6s forwards;
 }
 
-.category-icon {
-  display: inline-block;
-  animation: bounce 1s infinite;
+.product-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.product-icon {
+  width: 50px;
+  height: 50px;
+  object-fit: contain;
+  flex-shrink: 0;
 }
 
 @keyframes fadeSlide {
@@ -182,12 +189,3 @@ button.hamburger:hover {
   }
 }
 
-@keyframes bounce {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(-5px);
-  }
-}

--- a/frontend/src/assets/icons/audio.svg
+++ b/frontend/src/assets/icons/audio.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 50 50">
+  <rect width="50" height="50" fill="#ddd" />
+  <text x="25" y="28" font-size="10" text-anchor="middle" fill="#333">Audio</text>
+</svg>

--- a/frontend/src/assets/icons/ecu.svg
+++ b/frontend/src/assets/icons/ecu.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 50 50">
+  <rect width="50" height="50" fill="#ddd" />
+  <text x="25" y="28" font-size="10" text-anchor="middle" fill="#333">ECU</text>
+</svg>

--- a/frontend/src/assets/icons/lift.svg
+++ b/frontend/src/assets/icons/lift.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 50 50">
+  <rect width="50" height="50" fill="#ddd" />
+  <text x="25" y="28" font-size="10" text-anchor="middle" fill="#333">Lift</text>
+</svg>

--- a/frontend/src/assets/icons/part.svg
+++ b/frontend/src/assets/icons/part.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 50 50">
+  <rect width="50" height="50" fill="#ddd" />
+  <text x="25" y="28" font-size="10" text-anchor="middle" fill="#333">Part</text>
+</svg>

--- a/frontend/src/assets/icons/tire.svg
+++ b/frontend/src/assets/icons/tire.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 50 50">
+  <rect width="50" height="50" fill="#ddd" />
+  <text x="25" y="28" font-size="10" text-anchor="middle" fill="#333">Tire</text>
+</svg>

--- a/frontend/src/assets/icons/wheel.svg
+++ b/frontend/src/assets/icons/wheel.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 50 50">
+  <rect width="50" height="50" fill="#ddd" />
+  <text x="25" y="28" font-size="10" text-anchor="middle" fill="#333">Wheel</text>
+</svg>

--- a/frontend/src/pages/Products.jsx
+++ b/frontend/src/pages/Products.jsx
@@ -1,9 +1,23 @@
 import products from '../data/products.js';
+import wheel from '../assets/icons/wheel.svg';
+import tire from '../assets/icons/tire.svg';
+import lift from '../assets/icons/lift.svg';
+import audio from '../assets/icons/audio.svg';
+import ecu from '../assets/icons/ecu.svg';
+import part from '../assets/icons/part.svg';
 
 export default function Products({ search, onSearch, onAdd }) {
   const filtered = products.filter((item) =>
     item.name.toLowerCase().includes(search.toLowerCase()),
   );
+  const icons = {
+    Wheels: wheel,
+    Tires: tire,
+    'Lift Kits': lift,
+    Audio: audio,
+    'ECU Tuning': ecu,
+    'Performance Parts': part,
+  };
   const categories = Array.from(new Set(products.map((p) => p.category)));
   const grouped = filtered.reduce((acc, item) => {
     acc[item.category] = acc[item.category] || [];
@@ -25,21 +39,25 @@ export default function Products({ search, onSearch, onAdd }) {
         value={search}
         onChange={(e) => onSearch(e.target.value)}
       />
-      {categories.map((cat, idx) => {
+      {categories.map((cat) => {
         const items = grouped[cat] || [];
         if (items.length === 0) return null;
         return (
           <div key={cat}>
-            <h3 className="category-heading" style={{ animationDelay: `${idx * 0.1}s` }}>
-              <span className="category-icon">&#9656;</span>
-              {cat}
-            </h3>
+            <h3 className="category-heading">{cat}</h3>
             <ul>
               {items.map((item) => (
-                <li key={item.id}>
-                  <strong>{item.name}</strong> - ${item.price}
-                  <p>{item.description}</p>
-                  <button onClick={() => onAdd(item)}>Add to Cart</button>
+                <li key={item.id} className="product-item">
+                  <img
+                    className="product-icon"
+                    src={icons[item.category]}
+                    alt={item.category}
+                  />
+                  <div>
+                    <strong>{item.name}</strong> - ${item.price}
+                    <p>{item.description}</p>
+                    <button onClick={() => onAdd(item)}>Add to Cart</button>
+                  </div>
                 </li>
               ))}
             </ul>

--- a/frontend/src/pages/Services.jsx
+++ b/frontend/src/pages/Services.jsx
@@ -1,9 +1,16 @@
 export default function Services() {
   const services = [
-    'Routine Maintenance',
-    'Lift Kit Installation',
-    'Diagnostics',
-    'Custom Fabrication',
+    'Wheel and Tire Kits',
+    'Audio Upgrades',
+    'LED Lighting',
+    'Custom Roll Cages',
+    'Engine and Clutch Tuning',
+    'Aftermarket Exhausts',
+    'Transmission Repair & Gear Reductions',
+    'Suspension Tuning',
+    'Oil Changes and General Maintenance',
+    'Aftermarket Seats',
+    'And More..',
   ];
 
   return (


### PR DESCRIPTION
## Summary
- expand the Services page with a full list of offerings
- remove animated arrow from product categories
- display category icons beside each product
- add simple SVG icons for product categories

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687dd4111d908330a2e0dddd1b6ff7e2