### PR TITLE
Add cart notification and new color theme

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -6,6 +6,19 @@
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
+.notification {
+  position: fixed;
+  top: 70px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: var(--primary);
+  color: var(--surface);
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+}
+
 nav.nav {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Header from './components/Header';
 import Footer from './components/Footer';
 import Home from './pages/Home';
@@ -13,10 +13,20 @@ export default function App() {
   const [page, setPage] = useState('home');
   const [cart, setCart] = useState([]);
   const [search, setSearch] = useState('');
+  const [message, setMessage] = useState('');
 
-  const handleAdd = (item) => setCart([...cart, item]);
+  const handleAdd = (item) => {
+    setCart([...cart, item]);
+    setMessage(`${item.name} added to cart`);
+  };
   const handleRemove = (index) =>
     setCart(cart.filter((_, i) => i !== index));
+
+  useEffect(() => {
+    if (!message) return;
+    const timer = setTimeout(() => setMessage(''), 3000);
+    return () => clearTimeout(timer);
+  }, [message]);
 
   const renderPage = () => {
     switch (page) {
@@ -43,6 +53,7 @@ export default function App() {
 
   return (
     <>
+      {message && <div className="notification">{message}</div>}
       <Header current={page} onNavigate={setPage} />
       <main>{renderPage()}</main>
       <Footer />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,8 +1,8 @@
 :root {
-  --primary: #6dbf6d;
-  --primary-dark: #5aa75c;
+  --primary: #ff6d00;
+  --primary-dark: #e65100;
   --surface: #ffffff;
-  --surface-alt: #f0fff4;
+  --surface-alt: #fff7e6;
   font-family: 'Montserrat', system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.6;
   color: #222;


### PR DESCRIPTION
## Summary
- show a temporary notification whenever an item is added to the cart
- update the primary color palette to a bright orange scheme

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687dd5789c68833082ce67ef3d7eebe3